### PR TITLE
Require opt-ing in to exceptions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,6 +26,8 @@ JSON3 = "1.9"
 LinearAlgebra = "<0.0.1,1"
 Logging = "<0.0.1,1"
 MarkdownAST = "0.1.2"
+Pkg = "<0.0.1,1"
+ProgressMeter = "1.9"
 REPL = "<0.0.1,1"
 Random = "<0.0.1,1"
 StructTypes = "1.7"
@@ -38,7 +40,9 @@ pandoc_jll = "3.1.9"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "LinearAlgebra", "Test"]
+test = ["Aqua", "LinearAlgebra", "Pkg", "ProgressMeter", "Test"]

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It does so in a few ways:
 
 Demo:
 
-```julia {cast="true" allow_errors="false"}
+```julia {cast="true"}
 @info "Hello!"
 println("That was a logging statement, but this is printing.")
 x = rand(10, 10)

--- a/docs/src/documenter_usage.md
+++ b/docs/src/documenter_usage.md
@@ -80,27 +80,19 @@ Pkg.status()
 
 ### Exceptions
 
-Like in `@repl` blocks, exceptions are allowed. For example:
+Unlike in `@repl` blocks, exceptions are not allowed by default. Instead, they must be opt-ed in with `allow_errors=true`
 
 ````markdown
-```@cast
+```@cast; allow_errors=true
 error("This is an exception!")
 ```
 ````
 
 This looks like:
 
-```@cast
+```@cast; allow_errors=true
 error("This is an exception!")
 ```
-
-To prevent exceptions, use `allow_errors=false`, as in
-
-````markdown
-```@cast; allow_errors=false
-error("This is an exception!")
-```
-````
 
 ### Example with a named block
 
@@ -122,13 +114,13 @@ x*x
 The next block continues:
 
 ````markdown
-```@cast 1; hide_inputs=true
+```@cast 1; hide_inputs=true, allow_errors=true
 y = x+1
 sqrt(x)
 ```
 ````
 
-```@cast 1; hide_inputs=true
+```@cast 1; hide_inputs=true, allow_errors=true
 y = x+1
 sqrt(x)
 ```
@@ -183,7 +175,7 @@ Delay of 1:
 ### All supported options in `@cast` Documenter blocks
 
 * `hide_inputs::Bool=false`. Whether or not to hide the `@repl`-style inputs before the animated gif.
-* `allow_errors::Bool=true`. Whether or not the Documenter build should fail if exceptions are encountered during execution of the `@cast` block.
+* `allow_errors::Bool=false`. Whether or not the Documenter build should fail if exceptions are encountered during execution of the `@cast` block.
 * `delay::Float64=0.25`. The amount of delay between line executions (to emulate typing time).
 * `loop::Union{Int,Bool}=false`. Set to `true` for infinite looping, or an integer to loop a fixed number of times.
 * `height::Int`. Heuristically determined by default. Set to an integer to specify the number of lines.

--- a/docs/src/limitations.md
+++ b/docs/src/limitations.md
@@ -21,7 +21,7 @@ end
 
 One workaround here is to use a `begin` or `let` block, to group lines that need to share access to the `stdout` object:
 
-```@cast
+```@cast; height=10
 using ProgressMeter
 begin
 prog = ProgressThresh(1e-5; desc="Minimizing:")

--- a/docs/src/markdown_usage.md
+++ b/docs/src/markdown_usage.md
@@ -42,7 +42,7 @@ Here, the gifs are generated with [`agg`](https://github.com/asciinema/agg) (whi
 * `delay::Float64=0.25`. The amount of delay between line executions (to emulate typing time).
 * `font-size::Int=28`. Used by `agg` when generating the gif.
 * `height::Int`. Heuristically determined by default. Set to an integer to specify the number of lines.
-* `allow_errors::Bool=true`. Whether or not [`cast_document`](@ref) (or [`cast_readme`](@ref)) should fail if exceptions are encountered during execution of the block.
+* `allow_errors::Bool=false`. Whether or not [`cast_document`](@ref) (or [`cast_readme`](@ref)) should fail if exceptions are encountered during execution of the block.
 
 ### Syntax notes
 

--- a/src/gif.jl
+++ b/src/gif.jl
@@ -1,9 +1,9 @@
 """
-    save_code_gif(output_path, code_string; delay=0.25, font_size=28, height=nothing, allow_errors=true)
+    save_code_gif(output_path, code_string; delay=0.25, font_size=28, height=nothing, allow_errors=false)
 
 Given Julia source code as a string, run the code in a REPL mode and save the results as a gif to `output_path`.
 """
-function save_code_gif(output_path, code_string; delay=0.25, font_size=28, height=nothing, allow_errors=true)
+function save_code_gif(output_path, code_string; delay=0.25, font_size=28, height=nothing, allow_errors=false)
     cast = _cast_str(code_string, delay; height, allow_errors)
     save_gif(output_path, cast::Cast; font_size)
     return output_path
@@ -51,7 +51,7 @@ function cast_action(tag, content, format, meta; base_dir, counter)
     font_size = get_attribute(attributes, "font-size", 28)
     delay = get_attribute(attributes, "delay", 0.25)
     height = get_attribute(attributes, "height", 0)
-    allow_errors = get_attribute(attributes, "allow_errors", true)
+    allow_errors = get_attribute(attributes, "allow_errors", false)
     if height == 0
         height = nothing
     end

--- a/test/bad.md
+++ b/test/bad.md
@@ -1,3 +1,3 @@
-```julia {cast="true" allow_errors="false"}
+```julia {cast="true"}
 error("bad")
 ```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,6 +79,20 @@ end
         @test issorted(event.time for event in events)
         @test events[1].type == InputEvent
         @test strip(events[1].event_data) == "@info \"Hello!\""
+
+        # We can also test the `write_event!` pathway with `Event` objects.
+        # This also checks we can roundtrip effectively.
+        io2 = IOBuffer()
+        cast2 = Cast(io2, header)
+        for event in events
+            write_event!(cast2, event)
+        end
+        seekstart(io2)
+        header2, events2 = parse_cast(io2)
+        for property in propertynames(header)
+            @test getproperty(header, property) == getproperty(header2, property)
+        end
+        @test events == events2
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -117,11 +117,12 @@ end
 @testset "markdown parsing" begin
     tmp = mktempdir()
     output = joinpath(tmp, "output.md")
-    # Check that we can parse both blocks and produce the gif tags.
-    @test cast_document("test_doc.md", output) == 2
+    # Check that we can parse these blocks and produce the gif tags.
+    @test cast_document("test_doc.md", output) == 3
     str = read(output, String)
     @test contains(str, "output_1_@cast.gif")
     @test contains(str, "output_2_@cast.gif")
+    @test contains(str, "output_3_@cast.gif")
 end
 
 @testset "markdown errors" begin

--- a/test/test_doc.md
+++ b/test/test_doc.md
@@ -5,3 +5,7 @@
 ```julia {cast="true" font-size=28 delay=0.5}
 2+2
 ```
+
+```julia {cast="true" allow_errors="true"}
+error("oops")
+```


### PR DESCRIPTION
Otherwise it's too easy to miss erroring blocks. This contradicts `@repl`, but IMO that one has the wrong default.