### PR TITLE
Add width argument to Documenter

### DIFF
--- a/docs/src/documenter_usage.md
+++ b/docs/src/documenter_usage.md
@@ -172,6 +172,30 @@ Delay of 1:
 3
 ```
 
+### Window size
+
+The size of the window can be set with `height` and `width`.
+
+````markdown
+```@cast
+println("="^80)
+```
+````
+
+```@cast; hide_inputs=true
+println("="^80)
+```
+
+````markdown
+```@cast; width=50, height=10
+println("="^80)
+```
+````
+
+```@cast; width=50, height=10, hide_inputs=true
+println("="^80)
+```
+
 ### All supported options in `@cast` Documenter blocks
 
 * `hide_inputs::Bool=false`. Whether or not to hide the `@repl`-style inputs before the animated gif.
@@ -179,6 +203,7 @@ Delay of 1:
 * `delay::Float64=0.25`. The amount of delay between line executions (to emulate typing time).
 * `loop::Union{Int,Bool}=false`. Set to `true` for infinite looping, or an integer to loop a fixed number of times.
 * `height::Int`. Heuristically determined by default. Set to an integer to specify the number of lines.
+* `width::Int`. Set to `80` by default. Set to an integer to specify the number of columns.
 
 ### Reference docs
 

--- a/src/Asciicast.jl
+++ b/src/Asciicast.jl
@@ -153,7 +153,7 @@ function Base.show(io::IO, ::MIME"juliavscode/html", cast::Cast)
 end
 
 function show_html(io::IO, cast::Cast)
-        base64_str = base64encode(collect_bytes(cast))
+    base64_str = base64encode(collect_bytes(cast))
     name = uuid4()
     # Note: the extra div with `margin` is me trying to make the asciinema player
     # have a little space around it, so it looks better in documenter pages etc.
@@ -164,7 +164,7 @@ function show_html(io::IO, cast::Cast)
     <script>
     AsciinemaPlayer.create(
     'data:text/plain;base64,$(base64_str)',
-    document.getElementById('$(name)'), {autoPlay: true, fit: false, loop: $(cast.loop)}
+    document.getElementById('$(name)'), {autoPlay: true, fit: "width", loop: $(cast.loop)}
     );
     </script>
     </div>

--- a/src/runner.jl
+++ b/src/runner.jl
@@ -58,6 +58,12 @@ function Selectors.runner(::Type{CastBlocks}, node, page, doc)
             height = parse(Int, matched[1])
         end
 
+        # width
+        matched = match(r"\bwidth\s*=\s*([0-9]+)", kwargs)
+        if matched !== nothing
+            width = parse(Int, matched[1])
+        end
+
         # loop
         # bool:
         matched = match(r"\bloop\s*=\s*(true|false)\b", kwargs)
@@ -91,7 +97,8 @@ function Selectors.runner(::Type{CastBlocks}, node, page, doc)
 
     # If `height` isn't provided, we guess the number of lines:
     height = something(height, min(n_lines * 2, 24))
-    cast = Cast(IOBuffer(), Header(; height, idle_time_limit=1); delay, loop)
+    width = something(width, 80)
+    cast = Cast(IOBuffer(), Header(; height, width, idle_time_limit=1); delay, loop)
 
     cast_from_string!(x.code, cast; doc, page, ansicolor, mod, multicodeblock, allow_errors, x)
 

--- a/src/runner.jl
+++ b/src/runner.jl
@@ -62,6 +62,8 @@ function Selectors.runner(::Type{CastBlocks}, node, page, doc)
         matched = match(r"\bwidth\s*=\s*([0-9]+)", kwargs)
         if matched !== nothing
             width = parse(Int, matched[1])
+        else
+            width = nothing
         end
 
         # loop

--- a/src/runner.jl
+++ b/src/runner.jl
@@ -32,6 +32,7 @@ function Selectors.runner(::Type{CastBlocks}, node, page, doc)
     allow_errors = false
     delay = 0.25
     height = nothing
+    width = nothing
     loop = false
     if kwargs !== nothing
         # ansicolor


### PR DESCRIPTION
Closes #34.

@ericphanson I managed to add the argument, but I'm afraid I need a little more help here.
<img width="837" alt="grafik" src="https://github.com/user-attachments/assets/32785e1e-0651-44cb-97b5-955d28aa7223">
The width is now larger than before, and the lines are not wrapped anymore. However, the terminal itself is still the same size and the font as well, which means that the lines are clipped now.
Is there a way to make this work as intended? Thanks!
